### PR TITLE
Remove unnecessary environment variables

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -3,7 +3,7 @@
 set -e
 
 # So Docker variables can be loaded when running from cron
-export -p > /opt/letsencrypt/etc/global.env
+export -p | grep -v 'affinity:container' > /opt/letsencrypt/etc/global.env
 
 nginx.sh
 certbot.sh || true # Don't exit on failure on initial start to avoid triggering rate limits


### PR DESCRIPTION
When running under `docker-compose`, the `export -p` command export a variable with an invalid name:

```bash
bash-4.3# export -p
declare -x DOCKERIZE_VERSION="0.4.0"
declare -x DOMAINS="..."
declare -x EMAIL="..."
declare -x HAPROXY_IMAGE="dockercloud/haproxy:1.6.6"
declare -x HOME="/root"
declare -x HOSTNAME="1d22be675798"
declare -x OLDPWD
declare -x PATH="/opt/letsencrypt/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
declare -x PWD="/"
declare -x SHLVL="1"
declare -x TERM="xterm"
declare -x affinity:container
```

The presence of this variable prevents the cronjob from running:

```
bash-4.3# /etc/periodic/daily/certbot 
/opt/letsencrypt/etc/global.env: line 11: declare: `affinity:container': not a valid identifier
```

This patch ignores this variable when writing to the `global.env` file.